### PR TITLE
修复了两处环境变量没有正确读取的问题

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,14 +1,16 @@
+const dotenv = require('dotenv');
+dotenv.config();
+
 const express = require('express');
 const formidable = require('express-formidable');
 const apiControllers = require('./src/controllers');
-const dotenv = require('dotenv');
 const StaticRedis = require('./src/common-modules/static-redis');
 const CacheStaticRedis = require('./src/helepers/cache-redis/static-redis');
 const {getLogger} = require('./src/log');
 
 const log = getLogger('App');
 const expressApp = express();
-dotenv.config();
+
 
 const PID = process.pid;
 

--- a/web-js/build-dist.js
+++ b/web-js/build-dist.js
@@ -1,3 +1,4 @@
+process.chdir(__dirname);
 require('dotenv').config()
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION
第一处是在app.js中，Secret校验模块先于环境变量加载，故未能正确从.env环境变量中读取`API_SIGN_SECRET_KEY`；
第二处是在build_dist.js中，教程给出的打包命令`npm run build-dist`默认工作目录是`site-counter`，而打包相关的环境变量在`npm run build-dist/web-js`中，故在`build_dist.js`文件头修改工作目录为该文件所在目录。